### PR TITLE
REW-2335 - Using url instead of service_url

### DIFF
--- a/app/models/concerns/csv2db/active_storage_adapter.rb
+++ b/app/models/concerns/csv2db/active_storage_adapter.rb
@@ -33,7 +33,7 @@ module Csv2db::ActiveStorageAdapter
 
     set_current_host
 
-    file_attachment.service_url(
+    file_attachment.url(
       expires_in: LINK_MAX_EXPIRY.to_i,
       disposition: 'attachment'
     )


### PR DESCRIPTION
Using `url` instead of `service_url` as `service_url` will be deprecated from rails 7.0